### PR TITLE
feat: Apply Apr 23 postmortem insights — discipline for agent prompt changes

### DIFF
--- a/agents/meta-agent.md
+++ b/agents/meta-agent.md
@@ -36,6 +36,16 @@ When invoked, follow these steps:
    - Best practices for the domain
    - Output format specification
 9. **Write the file:** Save to `agents/<generated-agent-name>.md`
+10. **Note the prompt-change discipline in the PR:** New agents — and especially edits to existing ones — are prompt changes. In the PR description, call out which `model:` the agent targets, whether the prompt asks for terseness or reduced effort, and whether any hook or skill it relies on rewrites context. See `docs/architecture/prompt-change-discipline.md` for the four checks the reviewer will apply.
+
+## Approach for prompt edits
+
+When modifying an existing agent rather than creating one new:
+
+- **Make one change per commit** so any single edit can be bisected by revert. Bundled prompt changes hide regressions.
+- **Exercise the agent on every targeted model** before merging — Sonnet, Opus, and Haiku can all respond differently to the same edit.
+- **Be cautious with concision instructions.** "Be more concise", "minimize output", or "use less thinking" have repeatedly produced quality regressions in similar systems. Prefer a soak period or feature-flagged rollout for these.
+- **Audit context-management edits.** If the change touches hooks or skill instructions that clear or rewrite session state, confirm whether the clear runs once or every turn.
 
 ## Output Format
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -23,6 +23,7 @@ When invoked, follow these steps:
    - **Bugs:** Null references, race conditions, off-by-one errors, unhandled exceptions
    - **Performance:** N+1 queries, missing indexes, memory leaks, unbounded loops
    - **Future problems:** Tight coupling, missing error handling on critical paths, tech debt traps
+   - **Prompt changes (if the diff touches `agents/`, `skills/`, `hooks/hooks.json`, or `CLAUDE.md`):** Apply the four checks in `docs/architecture/prompt-change-discipline.md` — per-model behavioral risk, ablation discipline, concision-vs-quality tradeoffs, and context-preservation logic
 4. **Classify findings:**
    - **CRITICAL (blocking):** Security vulnerabilities, data loss risks — must fix before deploy
    - **WARNING (non-blocking):** Bugs and performance issues — should fix soon
@@ -37,6 +38,17 @@ When invoked, follow these steps:
 - Only block deployment for security issues
 - Review post-deployment if needed for speed
 - Be concise — developers should spend time fixing, not reading reviews
+
+## Reviewing prompt changes
+
+When the diff touches agent or skill prompts, behavioral regressions are the dominant failure mode. A change can pass tests, type-check, and lint while still degrading agent quality on production tasks. Apply the discipline in `docs/architecture/prompt-change-discipline.md`:
+
+- **Per-model risk:** Did the author exercise the change on every `model:` value the affected agent or skill targets? A change that improves Sonnet output can degrade Opus output and vice versa.
+- **Ablation:** Is this PR one prompt change, or several bundled together? Bundled changes cannot be bisected by revert. Flag this as a WARNING and ask for separate commits.
+- **Concision-vs-quality:** Does the change ask the agent to be shorter, faster, or use less reasoning? Verbosity- and effort-reducing instructions have repeatedly produced quality regressions. Confirm the tradeoff is intentional and consider a soak period before making it default.
+- **Context preservation:** Does the change touch hooks or skill instructions that clear, summarize, or rewrite the agent's working context? Confirm whether the clear runs once or every turn — clearing every turn produces forgetful agents.
+
+Flag any of these as a NOTE at minimum, or a WARNING if the author has not addressed them in the PR description.
 
 ## Output Format
 

--- a/docs/architecture/prompt-change-discipline.md
+++ b/docs/architecture/prompt-change-discipline.md
@@ -1,0 +1,69 @@
+# Prompt Change Discipline
+
+Modifying an agent's system prompt or a skill's instructions is a high-leverage change. Small wording shifts (e.g., asking for more concise output) can produce large, non-obvious behavioral regressions across the agent kit. This document describes the discipline this kit applies to such changes.
+
+These practices are distilled from Anthropic's April 23, 2026 postmortem on Claude Code quality regressions, where three separate prompt/config changes — a default reasoning-effort drop, a verbosity-reduction instruction, and a stale-session caching change — each shipped past human and automated review and degraded behavior in production.
+
+## What counts as a "prompt change"
+
+Any diff that touches one of the following:
+
+- `agents/*.md` — agent system prompts and frontmatter (`description`, `tools`, `model`, `permissionMode`)
+- `skills/**/SKILL.md` and `.claude/skills/**/SKILL.md` — workflow and pattern skills
+- `hooks/hooks.json` `prompt` entries — inline policy nudges
+- `CLAUDE.md` and any project-level instruction files
+
+These changes are reviewed differently from code changes because their failure modes are behavioral rather than syntactic.
+
+## Four checks before merging
+
+### 1. Per-model behavioral check
+
+The same prompt can produce meaningfully different behavior on Sonnet, Opus, and Haiku. The Apr 23 postmortem describes a verbosity-reduction instruction that degraded coding quality on the model targeted by the change while leaving others unaffected.
+
+For any prompt change:
+
+- Identify which `model:` values in the kit could be affected (default `sonnet`, plus any agent that overrides to `opus` or `haiku`).
+- Exercise the changed agent or skill on each affected model on at least one representative task before merging. Capture the output, not just whether it ran.
+- If the change is a tradeoff (verbosity, effort, terseness), record what the tradeoff is in the PR description.
+
+### 2. Ablation discipline
+
+Bundle one prompt change per PR where possible. When that is not possible:
+
+- Make each change a separate commit with a one-line rationale.
+- In the PR description, list each change and what behavior it is meant to alter.
+- Reviewers should be able to revert any single commit and see only that change reflected in behavior.
+
+The postmortem's verbosity instruction was a single sentence with broad downstream effects. Bundled prompt changes amplify that risk because regressions cannot be bisected by revert.
+
+### 3. Concision-vs-quality watch
+
+Changes that ask the agent to be shorter, faster, or use less reasoning are the highest-risk class of prompt edits. Treat these as carrying a soak period: prefer to land them behind a feature flag, on a non-default branch, or behind an explicit opt-in skill before making them the default.
+
+Examples of language that triggers this check:
+
+- "be concise", "minimize output", "don't explain"
+- "use less thinking", "default to medium effort", "skip reasoning"
+- "respond in under N words", "one-line answers"
+- adding `disable-model-invocation: true` to a previously auto-invoked skill
+
+If a PR contains language like the above, the reviewer must confirm the tradeoff is intentional and bounded.
+
+### 4. Context-preservation check
+
+Hooks and skill instructions can quietly clear or rewrite the agent's working context (extended thinking blocks, prior tool results, task list state). The Apr 23 caching bug cleared reasoning history on every turn instead of once per stale session, producing an agent that "would continue executing, but increasingly without memory of why it had chosen to do what it was doing."
+
+When a change touches context-management logic — `hooks/hooks.json` actions that interact with sessions, skills that instruct the agent to "forget" or "summarize and clear", or anything that resets task or memory state — the reviewer must explicitly note:
+
+- What context the change clears or rewrites
+- Whether it runs once or every turn
+- How a multi-turn task will behave under the change
+
+## Reviewer responsibilities
+
+The `reviewer` agent applies these checks when it observes a prompt change in the diff. Authors should call them out preemptively in the PR description so the reviewer can verify rather than discover.
+
+## Source
+
+Anthropic Engineering, "An update on recent Claude Code quality reports" (April 23, 2026): https://www.anthropic.com/engineering/april-23-postmortem


### PR DESCRIPTION
## Summary

Adds prompt-change discipline distilled from Anthropic's April 23, 2026 Claude Code postmortem ([source](https://www.anthropic.com/engineering/april-23-postmortem)). The post describes three separate prompt/config changes that each shipped past human and automated review and produced behavioral regressions:

1. A default reasoning-effort drop (high → medium) that degraded intelligence
2. A caching change that cleared extended thinking history every turn instead of once per stale session, producing forgetful agents
3. A verbosity-reduction system-prompt instruction that hurt coding quality

Each was caught only after user reports days to weeks later. The transferable lesson for an agent kit is that prompt edits fail behaviorally, not syntactically — lint and tests can't catch them, so they need their own review discipline.

## Changes

**New: `docs/architecture/prompt-change-discipline.md`** — four checks that apply when a diff touches `agents/`, `skills/`, `hooks/hooks.json`, or `CLAUDE.md`:
- Per-model behavioral check (Sonnet/Opus/Haiku diverge on the same prompt)
- Ablation discipline (one prompt change per commit, so regressions can be bisected by revert)
- Concision-vs-quality watch (verbosity- and effort-reducing instructions are the highest-risk class — prefer a soak period)
- Context-preservation check (audit hooks/skills that clear or rewrite session state, and confirm whether the clear runs once or every turn)

**Updated: `agents/reviewer.md`** — new "Prompt changes" review category in step 3, plus a dedicated "Reviewing prompt changes" section that operationalizes the four checks.

**Updated: `agents/meta-agent.md`** — step 10 directs authors to declare model targets, terseness/effort tradeoffs, and context rewrites in the PR description. New "Approach for prompt edits" section for modifications to existing agents (one change per commit, exercise on every targeted model, caution on concision instructions, audit context-management edits).

## Self-review against the new discipline

- **Per-model:** Reviewer is `sonnet`, meta-agent is `opus`. Both files are documentation/policy edits; behavioral exercise N/A for prose-only additions.
- **Ablation:** Three commits, each scoped to one file, so any can be reverted independently.
- **Concision:** None of the changes ask any agent to be shorter, faster, or use less reasoning.
- **Context preservation:** No hooks or session-state logic touched.

## Source

Anthropic Engineering, "An update on recent Claude Code quality reports" (Apr 23, 2026): https://www.anthropic.com/engineering/april-23-postmortem

This is the next iteration in the scheduled-task PR series after #17 (Nov 2025–Mar 2026 insights) and #18 (Scaling Managed Agents).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established formal discipline and review processes for prompt-related changes to ensure consistent AI agent behavior across model variants and maintain code stability through rigorous testing and validation protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->