### PR TITLE
ci: complete release pipeline — add npm publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,39 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
+
+  publish-npm:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run tests
+        run: npm test
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

Completes the release pipeline so that merged conventional-commit features actually ship to npm.

## What's broken

The pipeline today goes: **merge → release-please creates a version-bump PR → merge that → release-please tags a release → 🚫 nothing publishes.** The standalone `release.yml` that handled npm publish was deleted in `1f3bbf2` when release-please was introduced, but no replacement publish job was wired in.

Additionally, **PR #20's merge just failed release-please with "Bad credentials"** — the repo's `default_workflow_permissions` was silently flipped to `read` between Mar 25 and now. A workflow file's `permissions:` block can only restrict, never elevate, so the declared `contents: write` was denied. I fixed that setting via:

```
gh api -X PUT repos/bryanweaver/claude-agent-kit/actions/permissions/workflow \
  -f default_workflow_permissions=write -F can_approve_pull_request_reviews=true
```

That's a one-time repo-level change, not in this diff.

## What this PR adds

A `publish-npm` job in `release-please.yml` that:
- Runs only when `release-please.outputs.release_created == 'true'`
- Checks out the freshly-tagged commit (`ref: tag_name`)
- Runs the test suite as a final guard
- Publishes to npm with `--provenance` via OIDC trusted publishing

No `NPM_TOKEN` secret needed — but npmjs.com must have a **trusted publisher** configured on the `@bryanofearth/claude-agent-kit` package pointing to this exact workflow. If that wasn't set up after the prior OIDC commits (`a05c2c5`, `7af53ed`, `7370ffb`), the first publish run will fail with an auth error and you'll need to add the trusted publisher at https://www.npmjs.com/package/@bryanofearth/claude-agent-kit/access.

## Test plan
- [x] Workflow YAML is valid (passes `gh workflow view` parse)
- [ ] After merge: confirm release-please creates a release PR for the PR #20 work
- [ ] After merging the release PR: confirm `publish-npm` job runs and either succeeds or fails with a clear npm trusted-publisher message

🤖 Generated with [Claude Code](https://claude.com/claude-code)