### PR TITLE
fix(ci): switch release-please to release-type node so package.json gets bumped

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,39 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
+
+  publish-npm:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run tests
+        run: npm test
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          release-type: node
 
   publish-npm:
     needs: release-please


### PR DESCRIPTION
## Summary

Caught while watching #21 land: \`release-type: simple\` only updates CHANGELOG.md. It never touches \`package.json\`. That's why npm publish has been broken — every prior release-please run tagged a new version but left \`package.json\` frozen at \`3.0.0\`.

## State of the world

- npm latest version: **1.2.0** (last published Feb 2026)
- \`package.json\` version: **3.0.0** (set manually in the v3 migration #14)
- last git tag: **v3.0.1**
- release PR #22 wants to tag **v3.1.0** but only updates CHANGELOG.md

If #22 merges as-is and publish-npm runs, \`npm publish\` reads \`3.0.0\` from package.json, publishes 3.0.0, and the git tag (v3.1.0) won't match.

## Fix

Switch to \`release-type: node\`, which reads/writes \`package.json\` version. After this lands:

1. release-please will re-run on this merge
2. Release PR #22 gets updated (or replaced) to include a \`package.json\` bump alongside the CHANGELOG
3. Merging that PR → tag v3.1.0 → publish-npm publishes 3.1.0

## Caveat

This is a **big** version jump on npm (1.2.0 → 3.1.0), because the v3 migration was tagged but never published. Anyone consuming \`@bryanofearth/claude-agent-kit\` from npm is on 1.2.0; they'll get the breaking v3 changes and all subsequent work in one bump. That's accurate to reality — v3 *is* breaking — but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)