### PR TITLE
fix(ci): use NPM_TOKEN secret for npm publish auth

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,12 +39,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Run tests
         run: npm test
 
-      - name: Upgrade npm for OIDC support
+      - name: Upgrade npm for provenance support
         run: npm install -g npm@latest
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The v3.1.0 publish-npm job just failed with \`ENEEDAUTH\`. The OIDC trusted-publisher path isn't configured on npmjs.com (the UI doesn't surface a way to add one on your account/package), so falling back to classic token auth.

## Changes

- \`setup-node\` now sets \`registry-url: https://registry.npmjs.org\` so npm knows where to authenticate
- Publish step receives \`NODE_AUTH_TOKEN\` from \`secrets.NPM_TOKEN\`
- Keeps \`id-token: write\` so \`--provenance\` can still sign the attestation via OIDC (provenance and auth are separate concerns)

## What you need to do

1. **Generate an automation token on npm:**
   - Go to https://www.npmjs.com/settings/~/tokens (replace \`~\` with your username)
   - Click "Generate New Token" → **Granular Access Token**
   - Name: \`claude-agent-kit GitHub Actions\`
   - Expiration: pick something reasonable (90 days or 1 year)
   - Permissions: **Read and write** on packages → select \`@bryanofearth/claude-agent-kit\`
   - Click Generate, **copy the token immediately** (it's only shown once)
2. **Add the secret to the repo:**
   \`\`\`
   gh secret set NPM_TOKEN --repo bryanweaver/claude-agent-kit
   \`\`\`
   Paste the token when prompted.
3. **Merge this PR.**
4. After merge: I'll re-run the failed v3.1.0 publish-npm job. It picks up where it left off — release v3.1.0 is already tagged and on GitHub Releases; we just need to push the artifact to npm.

## Future migration

If npm's trusted-publisher UI becomes available for your account later, the OIDC path is still preferred. Revert this change and follow the trusted-publisher setup instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to enhance npm package publishing process with improved authentication and provenance verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bryanweaver/claude-agent-kit/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->