### PR TITLE
ci: add manual-dispatch publish workflow to publish v3.1.0 retroactively

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v3.1.0). Defaults to the latest release tag.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "ref=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            latest=$(gh release view --json tagName --jq .tagName)
+            echo "ref=$latest" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Run tests
+        run: npm test
+
+      - name: Upgrade npm for provenance support
+        run: npm install -g npm@latest
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

v3.1.0 is tagged with a GitHub Release but never reached npm because the publish job failed before NPM_TOKEN was wired in. \`gh run rerun\` can't help — GitHub re-runs use the workflow file at the original commit SHA, where the auth code didn't exist yet.

Pushing a no-op commit to main doesn't help either: release-please only triggers publish-npm when it creates a new release, which won't happen without a \`feat:\` or \`fix:\` commit.

## What this adds

A separate \`publish.yml\` workflow with \`workflow_dispatch\` trigger. Takes an optional \`tag\` input (defaults to latest GitHub Release), checks that tag out, runs tests, and publishes to npm with NPM_TOKEN + provenance attestation.

Once merged:
\`\`\`
gh workflow run publish.yml -f tag=v3.1.0
\`\`\`

The auto-publish flow in release-please.yml is unchanged; this is a manual escape hatch for catch-up scenarios and re-publishes.

## Test plan
- [x] YAML parses
- [ ] After merge: dispatch with \`tag=v3.1.0\`, confirm npm gets 3.1.0
- [ ] Verify provenance attestation visible on https://www.npmjs.com/package/@bryanofearth/claude-agent-kit

🤖 Generated with [Claude Code](https://claude.com/claude-code)