### PR TITLE
fix(ci): keep release-please tags as v${version}

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Why

Release PR #29 just opened proposing a **4.0.0** bump because release-please re-scanned all commits since day one — picking up breaking changes from the v3 migration that were already released.

Root cause: introducing \`.release-please-manifest.json\` in #28 switched release-please into component-tag mode, where it looks for tags shaped like \`claude-agent-kit-v3.1.1\`. None exist (all prior tags are plain \`v*\`), so release-please thinks this component has never been released and starts from scratch.

## Fix

Add \`include-component-in-tag: false\` to the config. release-please will use \`v\${version}\` tags, find the existing \`v3.1.1\` tag, and compute the next version from only the commits since then.

## Next step

After this merges:
1. Release-please re-runs, closes/replaces PR #29
2. New release PR opens — should be **3.1.2** (only the \`fix(plugin):\` from #28 plus this \`fix(ci):\` to publish)
3. Manually close PR #29 (it'll be superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)