### PR TITLE
feat(evals): Phase 1 — offline harness with rule grader + 3 reviewer cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ node_modules/
 .env.*
 !.env.example
 
+# Eval results — historical, not committed
+evals/results/
+
 # OS
 .DS_Store

--- a/docs/architecture/eval-strategy.md
+++ b/docs/architecture/eval-strategy.md
@@ -1,0 +1,86 @@
+# Eval Strategy
+
+How the kit evaluates whether its agents work as expected, and the deferred plan for scaling that evaluation if the kit grows.
+
+## Current state — Phase 1 only
+
+The kit ships with `evals/` containing:
+- **Offline runner** (`evals/runner.js`) — loads cases, returns each case's `mock_output`, applies the rule-based grader
+- **Rule grader** (`evals/graders/rule.js`) — classification, must/must-not-mention, word-count, regex
+- **Cases** (`evals/cases/<agent>/<id>.json`) — golden inputs + expected outputs
+
+Phase 1 has **no API calls and no recurring cost**. It is useful as:
+
+1. **Specification.** Each case documents what the agent is *supposed* to do better than prose docs can. Future readers (or future you) understand intent by reading the cases.
+2. **Spot-check tool.** Run `npm run evals` after a prompt change to confirm the mocks still grade correctly. Mostly catches dumb regressions in the mocks themselves, not behavioral regressions in the agents.
+3. **TODO with teeth.** New cases written with `mock_output` set to current-bad-output and `expected` set to desired-output will fail until the agent is fixed. This makes "I should improve the reviewer's X behavior someday" into a concrete, testable artifact.
+
+Phase 1 is **not** a substitute for behavioral evaluation. It does not run the agents. It does not catch a real prompt regression.
+
+## Deferred phases — build only when the trigger fires
+
+The trigger conditions for revisiting:
+
+- **High change cadence:** You start making non-trivial prompt changes more than ~once a month
+- **Observed regression:** Someone reports an agent behavior regression you cannot reproduce or explain
+- **Multiple maintainers:** A second contributor starts editing agent prompts and you need a shared definition of "correct"
+
+If none of these are true, **Phase 1 is enough.** Building 2-5 is over-engineered for a stable kit.
+
+### Phase 2 — Live runner
+
+Wire `@anthropic-ai/sdk`. The runner reads the agent's `.md` file as the system prompt, sends the case input as the user message, captures the response.
+
+- New script: `npm run evals -- --live`
+- Requires `ANTHROPIC_API_KEY` (env var locally, or as a GitHub secret for CI)
+- Cost: ~$0.01-0.05 per case per model, depending on which model and how long the response
+
+Approx work: ~half a day. Most of it is making the API call and threading the result through the existing runner. Cases don't need to change — the `mock_output` field is just ignored in live mode.
+
+### Phase 3 — LLM-as-judge grader
+
+Add `evals/graders/judge.js`. For rubrics that the rule grader can't express (e.g. "the explanation is clear", "the tone is appropriate"), Claude grades the agent's output against the rubric and returns a 0-5 score.
+
+**Calibration step is non-negotiable.** Before judge scores count for anything, the judge must agree with hand-grades on a calibration set of ~20 cases. Procedure:
+1. Pick 20 representative outputs
+2. Hand-grade them 0-5 yourself
+3. Have the judge grade the same 20
+4. If judge disagrees with you on > 3 of the 20, the rubrics are bad — rewrite them
+5. Repeat until agreement is within tolerance
+
+Approx work: ~1 day for the judge, ~half a day for calibration per agent.
+
+### Phase 4 — Coverage expansion
+
+- 5-10 cases per agent (currently 3 for reviewer only)
+- Per-model variants (same case run on sonnet/opus/haiku, results stored separately)
+- Multi-turn cases for agents that operate over multiple turns
+
+Approx work: ongoing, ~1-2 hours per case.
+
+### Phase 5 — CI integration
+
+- Smoke set on every PR — 3-5 cases, ~30s, ~$0.10
+- Full suite weekly — 40+ cases × 3 models, ~$20-50/wk
+- Regression gating: a PR that drops pass rate below a threshold blocks merge
+- Score history tracked in `evals/results/` (or moved to external storage if it grows)
+
+Approx work: ~1 day for workflows + thresholds. Ongoing maintenance: triage every failure.
+
+## Cost ballpark for the full pipeline
+
+| Item | Cost |
+|---|---|
+| Phase 2 dev | ~$5 in API credits to wire it up |
+| Phase 3 calibration | ~$10 per agent, one-time |
+| Phase 5 ongoing — smoke per PR | ~$0.10 × PR count |
+| Phase 5 ongoing — weekly full | ~$20-50/wk = $1k-2.5k/yr |
+
+These are estimates. The first live run will give you a real number. **For a free open-source plugin, this is not free.** Worth knowing before committing.
+
+## Decision rubric
+
+- Are you actively iterating on agent prompts? → Build Phase 2 at minimum.
+- Have you had a real behavioral regression slip through? → Build Phase 2 + 3.
+- Do you have ≥2 maintainers? → Build through Phase 5.
+- None of the above? → Stay at Phase 1. Revisit when one of these changes.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,69 @@
+# Evals
+
+Behavioral evaluation harness for the agent kit. Where the tests in `test/` validate file contracts and cross-references, this evaluates whether agents produce the right output for representative inputs.
+
+## Why
+
+Structural tests catch broken file paths. They cannot catch a reviewer agent that fails to flag a concision regression, or a meta-agent that forgets to call out per-model behavioral risk. Those failures are behavioral — only an eval will surface them.
+
+## Status
+
+**Phase 1 only. Phases 2-5 are deferred** — see `docs/architecture/eval-strategy.md` for the full plan and the conditions under which to revisit.
+
+Phase 1 (offline mock-output harness) is useful as:
+1. **Specification** — each case documents what the agent should do better than prose docs
+2. **Spot-check tool** — catches regressions in mock outputs / case structure
+3. **TODO with teeth** — write a case for desired-but-not-achieved behavior; it fails until the agent is improved
+
+Phase 1 does NOT run the agents. It does not catch behavioral regressions in the real prompts. Live evaluation requires Phase 2+, which is deferred until the kit grows enough to justify the cost.
+
+## Layout
+
+```
+evals/
+├── cases/<agent>/<case-id>.json    Golden inputs + expected output
+├── graders/                        Grading implementations
+├── runner.js                       Loads cases, runs agent (mock or real), invokes graders
+├── results/<timestamp>/            Historical pass/fail + full traces
+└── README.md
+```
+
+## Running
+
+```bash
+npm run evals              # full suite
+npm run evals -- --agent reviewer
+npm run evals -- --case reviewer-concision-001
+npm run evals -- --live    # use real Claude API (Phase 2+, requires ANTHROPIC_API_KEY)
+```
+
+Default is offline / mock mode — each case can supply a `mock_output` field that the runner returns instead of calling the API.
+
+## Case format
+
+```json
+{
+  "id": "reviewer-concision-001",
+  "agent": "reviewer",
+  "model": "sonnet",
+  "input": { ... },
+  "expected": {
+    "must_classify_as": "WARNING",
+    "must_mention": ["concision-vs-quality"],
+    "must_not_mention": [],
+    "max_words": 500
+  },
+  "rubric": "<one-paragraph description of what 'good' looks like>",
+  "mock_output": "<offline-mode response>"
+}
+```
+
+The `mock_output` field is only read in offline mode. In live mode, the runner calls Claude with the agent's prompt + the case input.
+
+## Operational principles
+
+- **Look at the data.** The runner saves the raw model output for every case to `results/<timestamp>/<case-id>.json` so failures can be inspected. Aggregate scores hide patterns.
+- **Calibrate the judge.** Before LLM-as-judge grades are trusted, the judge must agree with hand-grades on a small calibration set. If it disagrees, the judge is broken, not the agent under test.
+- **Grade outputs, not process.** What matters is whether the produced response meets the rubric, not the model's reasoning trace.
+- **Per-model.** Same case run on sonnet/opus/haiku; results stored separately. Same prompt produces different behavior across models.
+- **Track regressions over time.** A single pass/fail run is noise. The same eval over weeks tells you whether the kit is improving or degrading.

--- a/evals/cases/reviewer/reviewer-ablation-001.json
+++ b/evals/cases/reviewer/reviewer-ablation-001.json
@@ -1,0 +1,20 @@
+{
+  "id": "reviewer-ablation-001",
+  "agent": "reviewer",
+  "model": "sonnet",
+  "input": {
+    "task": "Review this PR before merge.",
+    "diff": "diff --git a/agents/reviewer.md b/agents/reviewer.md\n@@ -15,6 +15,8 @@\n- Be concise\n+- Be concise and direct\n+- Skip optional sections\n+- Use shorter sentences\ndiff --git a/agents/full-stack-developer.md b/agents/full-stack-developer.md\n@@ -22,3 +22,5 @@\n+- Default to medium effort thinking\n+- Skip explanation of routine code\ndiff --git a/hooks/hooks.json b/hooks/hooks.json\n@@ -8,1 +8,1 @@\n-\"prompt\": \"Verify all acceptance criteria are met.\"\n+\"prompt\": \"Verify all acceptance criteria are met. Be brief.\""
+  },
+  "expected": {
+    "must_classify_as": "WARNING",
+    "must_mention": [
+      "ablation",
+      "bundled",
+      "separate commits"
+    ],
+    "max_words": 500
+  },
+  "rubric": "This PR bundles five distinct prompt changes across three files. The reviewer must apply the ablation-discipline check from prompt-change-discipline.md and flag that these cannot be bisected if a behavioral regression appears. The reviewer should request the author split the changes into separate commits, one prompt change per commit. Multiple concision-reducing instructions also trigger the concision-vs-quality watch — a CRITICAL classification is also acceptable.",
+  "mock_output": "## Review Summary\n\n**Files reviewed:** 3\n**Critical issues:** 0\n**Warnings:** 2\n**Notes:** 0\n\n### Warnings (Should Fix)\n- [PR-level] **Bundled prompt changes — ablation discipline.** This PR contains at least five distinct prompt edits across agents/reviewer.md, agents/full-stack-developer.md, and hooks/hooks.json. Per prompt-change-discipline.md, bundled prompt changes cannot be bisected by revert if a regression appears. Please split into separate commits — one prompt change per commit — so the team can isolate any behavioral regression.\n\n- [PR-level] **Concision-vs-quality watch.** Three of the bundled edits ask the agent to be more concise, skip explanations, or default to lower-effort thinking. Verbosity- and effort-reducing instructions are the highest-risk class of prompt edit and have a documented history of degrading coding quality. Confirm the tradeoff is intentional and consider landing each behind a soak period before making them default.\n\n### Verdict\nREQUEST_CHANGES"
+}

--- a/evals/cases/reviewer/reviewer-concision-001.json
+++ b/evals/cases/reviewer/reviewer-concision-001.json
@@ -1,0 +1,19 @@
+{
+  "id": "reviewer-concision-001",
+  "agent": "reviewer",
+  "model": "sonnet",
+  "input": {
+    "task": "Review this PR before merge.",
+    "diff": "diff --git a/agents/full-stack-developer.md b/agents/full-stack-developer.md\n@@ -10,3 +10,6 @@\n You are a full-stack developer agent.\n+\n+## Output style\n+Be more concise in all responses. Minimize output. Use less reasoning."
+  },
+  "expected": {
+    "must_classify_as": "WARNING",
+    "must_mention": [
+      "concision",
+      "prompt-change-discipline"
+    ],
+    "max_words": 600
+  },
+  "rubric": "The reviewer must recognize the diff as a prompt change touching agents/, apply the four checks from prompt-change-discipline.md, and specifically flag the concision-reducing language as a high-risk class of change. Classification should be at least WARNING because the change is unverified across models and the concision-vs-quality tradeoff has documented regression history. The reviewer should reference prompt-change-discipline.md and at minimum mention per-model risk and the concision-vs-quality tradeoff.",
+  "mock_output": "## Review Summary\n\n**Files reviewed:** 1\n**Critical issues:** 0\n**Warnings:** 1\n**Notes:** 1\n\n### Warnings (Should Fix)\n- [agents/full-stack-developer.md:12-14] This diff touches an agent prompt and adds concision-reducing language (\"be more concise\", \"minimize output\", \"use less reasoning\"). Per docs/architecture/prompt-change-discipline.md, this is the highest-risk class of prompt edit — verbosity- and effort-reducing instructions have a documented history of degrading coding quality. Apply the four checks: (1) per-model behavioral check on every model the agent targets; (2) ablation — this should be a single-purpose commit so it can be reverted independently; (3) concision-vs-quality watch confirms the tradeoff is intentional and worth a soak period; (4) context-preservation check is moot here (no context-clearing logic touched).\n\n### Notes (Consider)\n- Consider landing this behind a feature flag or on a non-default skill before making it the default behavior.\n\n### Verdict\nAPPROVE_WITH_WARNINGS"
+}

--- a/evals/cases/reviewer/reviewer-sql-injection-001.json
+++ b/evals/cases/reviewer/reviewer-sql-injection-001.json
@@ -1,0 +1,20 @@
+{
+  "id": "reviewer-sql-injection-001",
+  "agent": "reviewer",
+  "model": "sonnet",
+  "input": {
+    "task": "Review this PR before merge.",
+    "diff": "diff --git a/api/users.js b/api/users.js\n@@ -5,5 +5,9 @@\n export async function getUser(req, res) {\n   const id = req.query.id;\n+  const result = await db.query(`SELECT * FROM users WHERE id = ${id}`);\n+  res.json(result.rows[0]);\n }"
+  },
+  "expected": {
+    "must_classify_as": "CRITICAL",
+    "must_mention": [
+      "SQL injection",
+      "parameterized"
+    ],
+    "must_not_mention": [],
+    "max_words": 400
+  },
+  "rubric": "The reviewer must identify the unsanitized template-literal interpolation of req.query.id directly into a SQL string as a SQL injection vulnerability. This is security-class, must classify as CRITICAL, and must propose the fix (parameterized query / prepared statement). The reviewer must block the deploy on this finding.",
+  "mock_output": "## Review Summary\n\n**Files reviewed:** 1\n**Critical issues:** 1\n**Warnings:** 0\n**Notes:** 0\n\n### Critical (Must Fix)\n- [api/users.js:7] **SQL injection vulnerability.** The user-supplied `req.query.id` is interpolated directly into the SQL string via template literal. An attacker can pass `?id=1 OR 1=1` to dump the entire users table, or worse. Use a parameterized query instead:\n\n  ```js\n  const result = await db.query('SELECT * FROM users WHERE id = $1', [id]);\n  ```\n\n  This is a blocking issue — do not deploy until fixed.\n\n### Verdict\nREQUEST_CHANGES"
+}

--- a/evals/graders/rule.js
+++ b/evals/graders/rule.js
@@ -1,0 +1,86 @@
+/**
+ * Rule-based grader. Cheap, deterministic, no API calls.
+ *
+ * Checks supported in case.expected:
+ *   must_classify_as:   one of CRITICAL | WARNING | NOTE (case-insensitive match in output)
+ *   must_mention:       array of substrings that must all appear in the output
+ *   must_not_mention:   array of substrings that must NOT appear
+ *   max_words:          integer; output word count must be <= this
+ *   min_words:          integer; output word count must be >= this
+ *   regex_match:        array of regex source strings; each must match the output
+ *
+ * Returns { pass: boolean, score: 0..1, failures: string[] }
+ */
+
+function countWords(s) {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export function grade(output, expected) {
+  const failures = [];
+  const checks = [];
+
+  if (expected.must_classify_as) {
+    checks.push('must_classify_as');
+    const wanted = expected.must_classify_as.toUpperCase();
+    // Match the classification label as a section header or inline mention.
+    // Allow optional plural so "WARNING" matches both "Warning" and "Warnings".
+    const found = new RegExp(`\\b${wanted}S?\\b`, 'i').test(output);
+    if (!found) {
+      failures.push(`Output must classify as ${wanted}; not found in output`);
+    }
+  }
+
+  if (Array.isArray(expected.must_mention)) {
+    for (const phrase of expected.must_mention) {
+      checks.push(`must_mention:${phrase}`);
+      if (!output.toLowerCase().includes(phrase.toLowerCase())) {
+        failures.push(`Output must mention "${phrase}"`);
+      }
+    }
+  }
+
+  if (Array.isArray(expected.must_not_mention)) {
+    for (const phrase of expected.must_not_mention) {
+      checks.push(`must_not_mention:${phrase}`);
+      if (output.toLowerCase().includes(phrase.toLowerCase())) {
+        failures.push(`Output must NOT mention "${phrase}"`);
+      }
+    }
+  }
+
+  if (typeof expected.max_words === 'number') {
+    checks.push('max_words');
+    const n = countWords(output);
+    if (n > expected.max_words) {
+      failures.push(`Output is ${n} words; max ${expected.max_words}`);
+    }
+  }
+
+  if (typeof expected.min_words === 'number') {
+    checks.push('min_words');
+    const n = countWords(output);
+    if (n < expected.min_words) {
+      failures.push(`Output is ${n} words; min ${expected.min_words}`);
+    }
+  }
+
+  if (Array.isArray(expected.regex_match)) {
+    for (const src of expected.regex_match) {
+      checks.push(`regex_match:${src}`);
+      if (!new RegExp(src).test(output)) {
+        failures.push(`Output must match /${src}/`);
+      }
+    }
+  }
+
+  const total = checks.length || 1;
+  const passed = total - failures.length;
+  return {
+    pass: failures.length === 0,
+    score: passed / total,
+    checks_total: total,
+    checks_passed: passed,
+    failures,
+  };
+}

--- a/evals/runner.js
+++ b/evals/runner.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Eval runner.
+ *
+ * Modes:
+ *   offline (default): reads case.mock_output and grades it. No API calls.
+ *   live:              calls Claude API with the agent's prompt + case input. Costs money.
+ *
+ * Usage:
+ *   node evals/runner.js
+ *   node evals/runner.js --agent reviewer
+ *   node evals/runner.js --case reviewer-concision-001
+ *   node evals/runner.js --live    (Phase 2+, requires ANTHROPIC_API_KEY)
+ *
+ * Output:
+ *   - Per-case PASS/FAIL line on stdout
+ *   - Aggregate summary at the end
+ *   - Full traces written to evals/results/<timestamp>/<case-id>.json
+ *   - Exits non-zero if any case fails
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { grade as ruleGrade } from './graders/rule.js';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const CASES_DIR = path.join(ROOT, 'evals', 'cases');
+const RESULTS_DIR = path.join(ROOT, 'evals', 'results');
+
+function parseArgs(argv) {
+  const args = { agent: null, case: null, live: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--agent') args.agent = argv[++i];
+    else if (argv[i] === '--case') args.case = argv[++i];
+    else if (argv[i] === '--live') args.live = true;
+  }
+  return args;
+}
+
+function loadCases({ agent, caseId }) {
+  if (!fs.existsSync(CASES_DIR)) return [];
+  const agentDirs = fs.readdirSync(CASES_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .filter(d => !agent || d.name === agent)
+    .map(d => d.name);
+
+  const cases = [];
+  for (const dir of agentDirs) {
+    const files = fs.readdirSync(path.join(CASES_DIR, dir)).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+      const data = JSON.parse(fs.readFileSync(path.join(CASES_DIR, dir, file), 'utf8'));
+      if (caseId && data.id !== caseId) continue;
+      cases.push({ ...data, _file: path.join('evals/cases', dir, file) });
+    }
+  }
+  return cases;
+}
+
+async function runCaseOffline(testCase) {
+  if (typeof testCase.mock_output !== 'string') {
+    throw new Error(
+      `Case ${testCase.id} has no mock_output; cannot run in offline mode. ` +
+      `Add a mock_output field or run with --live.`,
+    );
+  }
+  return testCase.mock_output;
+}
+
+async function runCaseLive(testCase) {
+  throw new Error(
+    `Live mode not implemented in Phase 1. Phase 2 will wire the Anthropic SDK. ` +
+    `For now, add mock_output to ${testCase.id} and run without --live.`,
+  );
+}
+
+function makeResultsDir() {
+  fs.mkdirSync(RESULTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dir = path.join(RESULTS_DIR, stamp);
+  fs.mkdirSync(dir);
+  return dir;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const cases = loadCases({ agent: args.agent, caseId: args.case });
+
+  if (cases.length === 0) {
+    console.error('No cases matched. Check --agent / --case filters or add cases under evals/cases/.');
+    process.exit(2);
+  }
+
+  console.log(`# Running ${cases.length} case(s) in ${args.live ? 'LIVE' : 'OFFLINE'} mode\n`);
+  const resultsDir = makeResultsDir();
+
+  let passed = 0;
+  let failed = 0;
+  const failures = [];
+
+  for (const testCase of cases) {
+    let output;
+    try {
+      output = args.live ? await runCaseLive(testCase) : await runCaseOffline(testCase);
+    } catch (err) {
+      console.log(`FAIL  ${testCase.id}  (${err.message})`);
+      failed++;
+      failures.push({ id: testCase.id, error: err.message });
+      continue;
+    }
+
+    const result = ruleGrade(output, testCase.expected || {});
+    const status = result.pass ? 'PASS' : 'FAIL';
+    const scorePct = Math.round(result.score * 100);
+    console.log(`${status}  ${testCase.id}  (${result.checks_passed}/${result.checks_total} checks, ${scorePct}%)`);
+    if (!result.pass) {
+      for (const f of result.failures) console.log(`        - ${f}`);
+      failed++;
+      failures.push({ id: testCase.id, ...result });
+    } else {
+      passed++;
+    }
+
+    // Save trace for "look at the data"
+    fs.writeFileSync(
+      path.join(resultsDir, `${testCase.id}.json`),
+      JSON.stringify({ case: testCase, output, result }, null, 2),
+    );
+  }
+
+  // Summary
+  const summary = {
+    timestamp: path.basename(resultsDir),
+    mode: args.live ? 'live' : 'offline',
+    total: cases.length,
+    passed,
+    failed,
+    pass_rate: cases.length ? passed / cases.length : 0,
+    failures: failures.map(f => f.id),
+  };
+  fs.writeFileSync(path.join(resultsDir, 'summary.json'), JSON.stringify(summary, null, 2));
+
+  console.log(`\n# Summary: ${passed}/${cases.length} passed (${Math.round(summary.pass_rate * 100)}%)`);
+  console.log(`# Results: evals/results/${path.basename(resultsDir)}/`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error('Runner error:', err);
+  process.exit(2);
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,18 @@
     "url": "https://github.com/bryanweaver/claude-agent-kit/issues"
   },
   "homepage": "https://github.com/bryanweaver/claude-agent-kit#readme",
+  "files": [
+    "agents/",
+    "skills/",
+    "hooks/",
+    ".claude-plugin/",
+    "settings.json",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test test/*.test.js",
+    "evals": "node evals/runner.js"
   }
 }


### PR DESCRIPTION
## Why

The structural tests in \`test/\` validate file contracts (paths exist, JSON parses, agent references resolve). They cannot catch behavioral failures — a reviewer agent that fails to flag a concision regression, or a meta-agent that forgets to call out per-model risk. Those failures need a behavioral eval.

## What this PR adds

\`\`\`
evals/
├── README.md                       Phase 1 scope + pointer to deferred plan
├── runner.js                       Load → run → grade → record traces
├── graders/rule.js                 Regex/classification/word-count
├── cases/reviewer/
│   ├── reviewer-concision-001.json
│   ├── reviewer-sql-injection-001.json
│   └── reviewer-ablation-001.json
└── results/                        Gitignored — per-run traces

docs/architecture/eval-strategy.md  Deferred Phase 2-5 plan with trigger
                                    conditions for revisiting

package.json
└── "files" field added             Exclude evals/, test/, docs/, .github/,
                                    *.patch from npm tarball
\`\`\`

## Scope decision

After weighing cost-vs-leverage for a kit this size, **Phase 1 only — Phases 2-5 deferred.** The full live-eval pipeline (~$1k-2.5k/yr in API spend, ongoing case maintenance, CI gating) is over-engineered for a stable kit with low change cadence. Phase 1 is still useful as:

1. **Specification.** Each case documents the agent's intended behavior more concretely than prose.
2. **Spot-check tool.** \`npm run evals\` after prompt changes catches dumb mock-output regressions.
3. **TODO with teeth.** Write a case for desired-but-not-yet-achieved behavior; it fails until the agent is fixed.

Trigger conditions for revisiting Phase 2-5 are documented in \`eval-strategy.md\`:
- Change cadence > 1 prompt change/month
- Observed behavioral regression that's not reproducible
- Multiple maintainers needing shared "correct" definition

## Side effect: npm package shrinks

Adding the \`files\` field excludes dev-only content from the npm tarball:

| | Before | After |
|---|---|---|
| Files in tarball | ~85 | 34 |
| Packed size | larger | 43.7 KB |
| Includes evals/, test/, docs/, .github/, *.patch | yes | **no** |

Plugin marketplace consumers (the main install path) are unaffected — they pull from git.

## Test plan
- [x] \`npm test\` — 189 structural tests pass
- [x] \`npm run evals\` — 3/3 reviewer cases pass against mocks
- [x] \`npm pack --dry-run\` — confirms evals/, test/, docs/, .github/ excluded
- [ ] After merge: future prompt-change PRs cite \`npm run evals\` results as part of the prompt-change-discipline checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)